### PR TITLE
Add extra option to convert markdown images into purely text-based references in Jira markup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,3 +7,5 @@ textarea {
 width: 80%;
 height: 10em;
 }
+
+label { display: block; }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 
 <h2>Convert between GitHub-flavored Markdown and Jira text.</h2>
 <p>Expanded to support alternative text for images (since the original project seems to be unmaintained)</p>
+<p>Now includes extra image conversion option for (when going from Markdown to Jira only) which converts images and their text alternative into text-based references only, showing the filename and alternative text (to work around Jira's recent change in how it deals with images...or doesn't).</p>
 
 <h3>MarkDown</h3>
 <textarea class="editor" id="m"># Biggest heading
@@ -59,6 +60,8 @@ preformatted piece of text
 so *no* further _formatting_ is done here
 ```
 </textarea>
+
+<label><input type="checkbox" id="imgconv" value="1"> Convert images and their text alternatives into a text-based reference only.</label>
 
 <h3>JIRA</h3>
 <textarea class="editor" id="j">h1. Biggest heading

--- a/js/J2M2.js
+++ b/js/J2M2.js
@@ -1,6 +1,7 @@
 /**
  * Original script by Fokke Zandbergen / https://github.com/FokkeZB/J2M
  * Horribly hacked to add needed support for alternative text for images by Patrick H. Lauke / https://github.com/patrickhlauke
+ * Additional helper function to turn Jira images into links (to work around Jira's new broken behaviour with images/attachments)
  */
 
 
@@ -229,6 +230,21 @@
 		return input;
 	};
 
+	/**
+	 * Takes Jira formatted text and munges images/alternative texts into just visible text with filename (and text alternative)
+	 *
+	 * @param {string} input
+	 * @returns {string}
+	 */
+	function imgJ(input) {
+		// Images with alt= among their parameters
+		input = input.replace(/(!([^|\n\s]+)\|([^\n!]*)alt=([^\n!\,]+?)(,([^\n!]*))?!)/g, '*Image ({{$2}}):* $4');
+		// Images with just other parameters (ignore them)
+		input = input.replace(/(!([^|\n\s]+)\|([^\n!]*)!)/g, '*Image ({{$2}})*');
+		// Images without any parameters or alt
+		input = input.replace(/(!([^\n\s!]+)!)/g, '*Image ({{$2}})*');
+		return input;
+	};
 
 	/**
 	 * Exports object
@@ -236,7 +252,8 @@
 	 */
 	var J2M = {
 		toM: toM,
-		toJ: toJ
+		toJ: toJ,
+		imgJ: imgJ
 	};
 
 	// exporting that can be used in a browser and in node

--- a/js/script.js
+++ b/js/script.js
@@ -4,6 +4,7 @@
 (function () {
 	var jiraInput = document.getElementById("j");
 	var markdownInput = document.getElementById("m");
+	var markdownImageHandling = document.getElementById("imgconv");
 
 	var jiraCallback = function () {
 	  var markdown = J2M.toM(jiraInput.value);
@@ -12,6 +13,9 @@
 
 	var markdownCallback = function () {
 	  var jira = J2M.toJ(markdownInput.value);
+	  if (markdownImageHandling.checked) {
+		  jira = J2M.imgJ(jira);
+	  }
 	  jiraInput.value = jira;
 	};
 
@@ -20,4 +24,5 @@
 
 	markdownInput.addEventListener('keyup', markdownCallback);
 	markdownInput.addEventListener('blur', markdownCallback);
+	markdownImageHandling.addEventListener('change', markdownCallback);
 })();


### PR DESCRIPTION
to work around all the issues with Jira's new WYSIWYG-only view, and the cases where it does allow text editing but changes the filenames of attachments, breaking the image references.

Changes images from markdown

```
![alternative text](filename.jpg)
```

to

```
*Image ({{filename.jpg}}):* alternative text
```