### PR TITLE
Fix globals, cite regex, header parsing, typos...

### DIFF
--- a/js/J2M2.js
+++ b/js/J2M2.js
@@ -47,7 +47,7 @@
 		});
 
 		input = input.replace(/\{\{([^}]+)\}\}/g, '`$1`');
-		input = input.replace(/\?\?[^?](?:.*?[^?])?\?\?/g, '<cite>$1</cite>');
+		input = input.replace(/\?\?([^?](?:.*?[^?])?)\?\?/g, '<cite>$1</cite>');
 		input = input.replace(/\+([^+]*)\+/g, '<ins>$1</ins>');
 		input = input.replace(/\^([^^]*)\^/g, '<sup>$1</sup>');
 		input = input.replace(/~([^~]*)~/g, '<sub>$1</sub>');

--- a/js/J2M2.js
+++ b/js/J2M2.js
@@ -42,12 +42,12 @@
 		});
 
 		// headers, must be after numbered lists
-		input = input.replace(/^h([0-6])\.(.*)$/gm, function (match,level,content) {
+		input = input.replace(/^h([1-6])\.(.*)$/gm, function (match,level,content) {
 			return Array(parseInt(level) + 1).join('#') + content;
 		});
 
 		input = input.replace(/\{\{([^}]+)\}\}/g, '`$1`');
-		input = input.replace(/\?\?((?:.[^?]|[^?].)+)\?\?/g, '<cite>$1</cite>');
+		input = input.replace(/\?\?[^?](?:.*?[^?])?\?\?/g, '<cite>$1</cite>');
 		input = input.replace(/\+([^+]*)\+/g, '<ins>$1</ins>');
 		input = input.replace(/\^([^^]*)\^/g, '<sup>$1</sup>');
 		input = input.replace(/~([^~]*)~/g, '<sub>$1</sub>');
@@ -55,47 +55,42 @@
 
 		input = input.replace(/\{code(:([a-z]+))?\}([^]*?)\{code\}/gm, '```$2$3```');
 		input = input.replace(/\{quote\}([^]*)\{quote\}/gm, function(match, content) {
-			lines = content.split(/\r?\n/gm);
+			var quoteLines = content.split(/\r?\n/gm);
 
-			for (var i = 0; i < lines.length; i++) {
-				lines[i] = '> ' + lines[i];
+			for (var i = 0; i < quoteLines.length; i++) {
+				quoteLines[i] = '> ' + quoteLines[i];
 			}
 
-			return lines.join("\n");
+			return quoteLines.join("\n");
 		});
 
 		// Images with alt= among their parameters
-		input = input.replace(/!([^|\n\s]+)\|([^\n!]*)alt=([^\n!\,]+?)(,([^\n!]*))?!/g, '![$3]($1)');
+		input = input.replace(/!([^|\n\s]+)\|([^\n!]*)alt=([^\n!\\,]+?)(,([^\n!]*))?!/g, '![$3]($1)');
 		// Images with just other parameters (ignore them)
 		input = input.replace(/!([^|\n\s]+)\|([^\n!]*)!/g, '![]($1)');
 		// Images without any parameters or alt
 		input = input.replace(/!([^\n\s!]+)!/g, '![]($1)'); 
 
 		input = input.replace(/\[([^|]+)\|(.+?)\]/g, '[$1]($2)');
-		input = input.replace(/\[(.+?)\]([^\(]+)/g, '<$1>$2');
+		input = input.replace(/\[(.+?)\]([^\\(]+)/g, '<$1>$2');
 
 		input = input.replace(/{noformat}/g, '```');
 		input = input.replace(/{color:([^}]+)}([^]*?){color}/gm, '<span style="color:$1">$2</span>');
 
 		// Convert header rows of tables by splitting input on lines
-		lines = input.split(/\r?\n/gm);
-		lines_to_remove = []
+		var lines = input.split(/\r?\n/gm);
 		for (var i = 0; i < lines.length; i++) {
-			line_content = lines[i];
 
-			seperators = line_content.match(/\|\|/g);
-			if (seperators != null) {
+			var separators = lines[i].match(/\|\|/g);
+			if (separators != null) {
 				lines[i] = lines[i].replace(/\|\|/g, "|");
-				console.log(seperators)
 
 				// Add a new line to mark the header in Markdown,
 				// we require that at least 3 -'s are between each |
-				header_line = "";
-				for (var j = 0; j < seperators.length-1; j++) {
-					header_line += "|---";
+				var header_line = "|";
+				for (var j = 0; j < separators.length-1; j++) {
+					header_line += "-|";
 				}
-
-				header_line += "|";
 
 				lines.splice(i+1, 0, header_line);
 
@@ -187,7 +182,6 @@
 		};
 
 		input = input.replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)<\/\\1>', 'g'), function (match,from,content) {
-			//console.log(from);
 			var to = map[from];
 			return to + content + to;
 		});
@@ -212,11 +206,9 @@
 
 		// Convert header rows of tables by splitting input on lines
 		lines = input.split(/\r?\n/gm);
-		lines_to_remove = []
 		for (var i = 0; i < lines.length; i++) {
-			line_content = lines[i];
 
-			if (line_content.match(/\|---/g) != null) {
+			if (lines[i].match(/\|---/g) != null) {
 				lines[i-1] = lines[i-1].replace(/\|/g, "||")
 				lines.splice(i, 1)
 			}

--- a/js/J2M2.js
+++ b/js/J2M2.js
@@ -71,7 +71,7 @@
 		// Images without any parameters or alt
 		input = input.replace(/!([^\n\s!]+)!/g, '![]($1)'); 
 
-		input = input.replace(/\[([^|]+)\|(.+?)\]/g, '[$1]($2)');
+		input = input.replace(/\[([^|]+)\|(.+?)(?:\|smart-link)?\]/g, '[$1]($2)');
 		input = input.replace(/\[(.+?)\]([^\\(]+)/g, '<$1>$2');
 
 		input = input.replace(/{noformat}/g, '```');


### PR DESCRIPTION
You seem to be the maintainer now so I'll pass on the fixes I made locally to you =) . It's pretty messy code to begin with but I hope this helps!

- Stop using globals (`line_content`, `header_line`, `seperators`, etc) by adding "var"
- Fix not escaping `\` in the `[]` operator
- Remove `lines_to_remove ` as it's not used
- Remove console.log's
- Rename `seperators` to `separators` (spelling)
- Move `line_content` references to just use `lines[i]`
- Stop having a variable collision in quote replacement function by using `quoteLines` instead of `lines`
- Update header line generation to be more optimized

Lots of changes could be added to make this easier to read/maintain:
- use lambas
- use `let` and `const`
- clean up some logic by using for-loops instead of `Array(number).join('#')`, etc.